### PR TITLE
Remove calendar from public page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -278,12 +278,6 @@
             ></iframe>
         </div>
 
-        <div class="m-5 flex flex-col items-center">
-            <h1 class="text-xl mb-5 font-bold">Prochaines Dates</h1>
-            <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=2&bgcolor=%23ffffff&ctz=Europe%2FParis&src=c3FpZ2MxaGdkZDZ2M2k3Z2ZqcWJrNHZkOWdAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=YnZqODlwOXU1dTk4cjRqOGE4bThscG04NGtAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=ZXJibWxjdmRoZjNnODBqOHJ0MWtjajhxdDBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&src=aXZsa2E0NzBncHB1dDZjNGk2dmJta2s2cG9rZXJsYmpAaW1wb3J0LmNhbGVuZGFyLmdvb2dsZS5jb20&color=%237CB342&color=%2333B679&color=%23F4511E&color=%23F09300&mode=AGENDA&showTitle=0&showNav=0&showDate=0&showPrint=0&showTabs=0&showCalendars=0&showTz=0"
-                    style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-        </div>
-
         <div class="m-5 flex flex-col items-center md:col-span-2">
             <h1 class="text-xl mb-5 font-bold">
                 <a


### PR DESCRIPTION
The calendar was removed from the source HTML in
3cd7f0151f40a757dec7d2c014a9c33094dfdc2e but the page wasn’t rebuilt.