### PR TITLE
Warn when published site differs from source

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,27 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+current_tree=$(git write-tree)
+# Inspired from:
+# https://github.com/pre-commit/pre-commit/blob/84372e0edc7f5ac08361a10bcd312bc80dd20960/pre_commit/staged_files_only.py#L50
+has_changes=$(git diff-index --binary --no-color --no-ext-diff $current_tree)
+if [[ -n $has_changes ]]; then
+    git stash push --keep-index
+    echo "Stashing unstaged changes…"
+    trap 'git stash pop --quiet' EXIT
+fi
+
+npm run build >/dev/null
+
+SUCCESS=0
+# Is there an unstaged modification in docs/?
+# grep --silent exits with 1 when there are no matches, 0 otherwise.
+git status -z --porcelain docs/ | grep --silent --null-data --extended-regexp '^ M ' || SUCCESS=1
+
+if (( $SUCCESS == 0 )); then
+    # Theoretically could restore the entire tree. Out of caution, only restore
+    # the docs/ directory.
+    git restore docs/
+    echo "Unstaged modifications of the docs folders were found after build."
+    exit 1
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -795,6 +795,12 @@
             "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
             "dev": true
         },
+        "husky": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
+            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+            "dev": true
+        },
         "import-cwd": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Ultimate Thorigné Fouillard Webpage",
   "scripts": {
     "build": "cross-env vite build",
+    "prepare": "husky install",
     "serve": "cross-env vite serve"
   },
   "license": "MIT",
@@ -10,6 +11,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.0",
     "cross-env": "^7.0.3",
+    "husky": "^7.0.4",
     "prettier": "^2.4.1",
     "tailwindcss": "^2.2.19",
     "vite": "^2.6.14"


### PR DESCRIPTION
Add a hook to verify the published site version matches the source.
Commit hooks can be bypassed using the `--no-verify` flag.