### PR TITLE
Improve links color contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             <h1 class="text-xl mb-5 font-bold">Contact</h1>
             <p class="">Martin Mouterde</p>
             <p>06 46 19 03 <span class="endPhone"></span></p>
-            <p><a class="underline text-yellow-600" href="mailto:club@ultimate-thorigne-fouillard.fr">club@ultimate-thorigne-fouillard.fr</a>
+            <p><a class="underline text-yellow-700" href="mailto:club@ultimate-thorigne-fouillard.fr">club@ultimate-thorigne-fouillard.fr</a>
             </p>
         </div>
 
@@ -114,7 +114,7 @@
                                     <ul class="list-inside list-disc">
                                         <li class="mb-2"><a href="https://goo.gl/forms/ozshI4SnxDzDdviF3"
                                                             target="_blank"
-                                                            class="underline text-yellow-600">Formulaire
+                                                            class="underline text-yellow-700">Formulaire
                                             d'inscription</a>
                                         </li>
                                         <li class="my-2">75€ d'Adhésion, si possible par virement
@@ -126,43 +126,43 @@
                                         <li class="my-2">une photo d’identité
                                         </li>
                                         <li class="my-2"><a
-                                                class="underline text-yellow-600"
+                                                class="underline text-yellow-700"
                                                 href="http://www.ultimate-thorigne-fouillard.fr/documents/autorisation-jeunes.pdf"
                                                 target="_blank">une autorisation parentale</a>
                                         </li>
-                                        <li class="my-2">signer <a class="underline text-yellow-600"
+                                        <li class="my-2">signer <a class="underline text-yellow-700"
                                                                    target="_blank"
                                                                    href="https://www.ffdf.fr/wp-content/uploads/2021/07/Notice-individuelle-FFFD_MAIF_21_22.pdf">la
                                             notice d'assurance</a> <a
-                                                class="underline text-yellow-600 text-xs"
+                                                class="underline text-yellow-700 text-xs"
                                                 href="https://www.ffdf.fr/wp-content/uploads/2021/07/Garanties-FFFD_MAIF_21_22.pdf"
                                                 target="_blank">voir les garanties</a>
                                         </li>
-                                        <li class="my-2">un certificat médical (<a class="underline text-yellow-600"
+                                        <li class="my-2">un certificat médical (<a class="underline text-yellow-700"
                                                                                    href="http://www.ultimate-thorigne-fouillard.fr/documents/certificat.pdf"
                                                                                    target="_blank">modèle fédéral
-                                            obligatoire</a>) ou <a class="underline text-yellow-600"
+                                            obligatoire</a>) ou <a class="underline text-yellow-700"
                                                                    href="http://www.ultimate-thorigne-fouillard.fr/documents/attestation.pdf"
                                                                    target="_blank">une attestation</a>.
                                             L’attestation remplace le certificat médical, si vous avez
                                             répondu non à <a
-                                                    class="underline text-yellow-600"
+                                                    class="underline text-yellow-700"
                                                     href="http://www.ultimate-thorigne-fouillard.fr/documents/Questionnaire_Sante_Mineur.pdf"
                                                     target="_blank">toutes les questions</a>.
 
                                         </li>
                                         <li class="my-2">Tous les documents sont à envoyer par mail à <a
-                                                class="underline text-yellow-600"
+                                                class="underline text-yellow-700"
                                                 href="mailto:club@ultimate-thorigne-fouillard.fr">club@ultimate-thorigne-fouillard.fr</a>
                                         </li>
-                                        <li class="my-2">Les dispositifs <a class="underline text-yellow-600"
+                                        <li class="my-2">Les dispositifs <a class="underline text-yellow-700"
                                                                             target="_blank"
                                                                             href="https://www.ancv.com/le-coupon-sport">Coupon
                                             Sport</a>, <a
-                                                class="underline text-yellow-600"
+                                                class="underline text-yellow-700"
                                                 href="http://sortir-rennesmetropole.fr/" target="_blank">Sortir!</a>,
                                             et
-                                            <a class="underline text-yellow-600"
+                                            <a class="underline text-yellow-700"
                                                href="https://www.sports.gouv.fr/"
                                                target="_blank"
                                             >Pass'sport</a> sont
@@ -199,7 +199,7 @@
                                     <ul class="list-inside list-disc">
                                         <li class="mb-2"><a href="https://goo.gl/forms/V77PayoLvA8pojEr2"
                                                             target="_blank"
-                                                            class="underline text-yellow-600">Formulaire
+                                                            class="underline text-yellow-700">Formulaire
                                             d'inscription</a>
                                         </li>
                                         <li class="my-2">Adhésion, si possible par virement
@@ -213,40 +213,40 @@
                                         </li>
                                         <li class="my-2">une photo d’identité
                                         </li>
-                                        <li class="my-2">signer <a class="underline text-yellow-600"
+                                        <li class="my-2">signer <a class="underline text-yellow-700"
                                                                    target="_blank"
                                                                    href="https://www.ffdf.fr/wp-content/uploads/2021/07/Notice-individuelle-FFFD_MAIF_21_22.pdf">la
                                             notice d'assurance</a> <a
-                                                class="underline text-yellow-600 text-xs"
+                                                class="underline text-yellow-700 text-xs"
                                                 href="https://www.ffdf.fr/wp-content/uploads/2021/07/Garanties-FFFD_MAIF_21_22.pdf"
                                                 target="_blank">voir les garanties</a>
                                         </li>
-                                        <li class="my-2">un certificat médical (<a class="underline text-yellow-600"
+                                        <li class="my-2">un certificat médical (<a class="underline text-yellow-700"
                                                                                    href="http://www.ultimate-thorigne-fouillard.fr/documents/certificat.pdf"
                                                                                    target="_blank">modèle fédéral
-                                            obligatoire</a>) ou <a class="underline text-yellow-600"
+                                            obligatoire</a>) ou <a class="underline text-yellow-700"
                                                                    href="http://www.ultimate-thorigne-fouillard.fr/documents/attestation.pdf"
                                                                    target="_blank">une attestation</a>.
                                             L’attestation remplace le certificat médical pour une réinscription, si
                                             votre dernier certificat date de moins de 3 ans <b>et</b> que vous avez
                                             répondu non à <a
-                                                    class="underline text-yellow-600"
+                                                    class="underline text-yellow-700"
                                                     href="http://www.ultimate-thorigne-fouillard.fr/documents/questionnaire.pdf"
                                                     target="_blank">toutes les questions</a>.
 
                                         </li>
                                         <li class="my-2">Tous les documents sont à envoyer par mail à <a
-                                                class="underline text-yellow-600"
+                                                class="underline text-yellow-700"
                                                 href="mailto:club@ultimate-thorigne-fouillard.fr">club@ultimate-thorigne-fouillard.fr</a>
                                         </li>
-                                        <li class="my-2">Les dispositifs <a class="underline text-yellow-600"
+                                        <li class="my-2">Les dispositifs <a class="underline text-yellow-700"
                                                                             target="_blank"
                                                                             href="https://www.ancv.com/le-coupon-sport">Coupon
                                             Sport</a>, <a
-                                                class="underline text-yellow-600"
+                                                class="underline text-yellow-700"
                                                 href="http://sortir-rennesmetropole.fr/" target="_blank">Sortir!</a>,
                                             et
-                                            <a class="underline text-yellow-600"
+                                            <a class="underline text-yellow-700"
                                                href="https://www.sports.gouv.fr/"
                                                target="_blank"
                                             >Pass'sport</a>, sont


### PR DESCRIPTION
Accessibility tools report an insufficient contrast between the page
background and links colors. Use a darker shade for improved readability.