### PR TITLE
Update partners links

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@
                     >
                 </a>
                 <a
-                        href="https://sortir-rennesmetropole.fr/"
+                        href="https://www.soprasteria.com/"
                         target="_blank"
                         class="mx-10 underline flex flex-col items-center"
                 >
@@ -370,7 +370,7 @@
                     />
                     <span class="my-2">Sopra Stéria</span> </a
                 ><a
-                    href="https://www.sports.gouv.fr/"
+                    href="https://sports.gouv.fr/pratiques-sportives/sports-pour-tous/pass-sport/"
                     target="_blank"
                     class="mx-10 underline flex flex-col items-center"
             >


### PR DESCRIPTION
A typo caused the link not to point to Sopra Steria.
Point to a more specific page about Pass’Sport.