### PR TITLE
Remove horizontal scroll on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,8 +90,8 @@
             </p>
         </div>
 
-        <div class="m-5 flex flex-col items-center w-full">
-            <div class="flex  w-full flex-col md:flex-row">
+        <div class="m-5 flex flex-col items-center">
+            <div class="flex flex-col md:flex-row">
                 <div class="md:w-1/2 flex justify-center p-4 border">
                     <div class="flex flex-col">
                         <h1 class="text-xl mb-5 font-bold">


### PR DESCRIPTION
The `w-full` directive causes the element to take the available width.
A margin of 5 is also applied to the element, causing the element and
its margin to exceed the viewport width.